### PR TITLE
Upgrade devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,13 @@
   },
   "homepage": "https://github.com/uoc-advanced-html-css/uoc-boilerplate#readme",
   "devDependencies": {
-    "@parcel/transformer-sass": "^2.12.0",
-    "autoprefixer": "^10.4.15",
+    "@parcel/transformer-sass": "^2.13.2",
+    "autoprefixer": "^10.4.20",
     "npm-run-all": "^4.1.5",
-    "parcel": "^2.12.0",
-    "postcss-preset-env": "^9.1.1",
-    "posthtml-include": "^1.7.4",
-    "rimraf": "^5.0.1",
-    "sharp": "^0.31.3"
+    "parcel": "^2.13.2",
+    "postcss-preset-env": "^10.1.1",
+    "posthtml-include": "^2.0.1",
+    "rimraf": "^6.0.1",
+    "sharp": "^0.33.5"
   }
 }


### PR DESCRIPTION
Two weeks ago, parcel 2.13 was released, and added many changes.
https://github.com/parcel-bundler/parcel/releases/tag/v2.13.0

A few days later, they published two minor versions and they fixed some bugs.
https://github.com/parcel-bundler/parcel/releases/tag/v2.13.1
https://github.com/parcel-bundler/parcel/releases/tag/v2.13.2

The current version of parcel is 2.13.2 at the moment.

You could reproduce the changes by running the command below. It also upgrades the other packages:
```
npx npm-check-updates -u
```

Please note that the current installation output reports an unsupported version of node that must be bumped to node 20 or 22.
```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'glob@11.0.0',
npm warn EBADENGINE   required: { node: '20 || >=22' },
npm warn EBADENGINE   current: { node: 'v18.20.5', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'minimatch@10.0.1',
npm warn EBADENGINE   required: { node: '20 || >=22' },
npm warn EBADENGINE   current: { node: 'v18.20.5', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'jackspeak@4.0.2',
npm warn EBADENGINE   required: { node: '20 || >=22' },
npm warn EBADENGINE   current: { node: 'v18.20.5', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'lru-cache@11.0.2',
npm warn EBADENGINE   required: { node: '20 || >=22' },
npm warn EBADENGINE   current: { node: 'v18.20.5', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'path-scurry@2.0.0',
npm warn EBADENGINE   required: { node: '20 || >=22' },
npm warn EBADENGINE   current: { node: 'v18.20.5', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'rimraf@6.0.1',
npm warn EBADENGINE   required: { node: '20 || >=22' },
npm warn EBADENGINE   current: { node: 'v18.20.5', npm: '10.8.2' }
npm warn EBADENGINE }
```